### PR TITLE
Rename crate to `retour`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+
+name: Open a release PR
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to release
+        required: true
+        type: string
+
+jobs:
+  make-release-pr:
+    permissions:
+      id-token: write # Enable OIDC
+      pull-requests: write
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: chainguard-dev/actions/setup-gitsign@main
+
+      - name: Check semver
+        uses: obi1kenobi/cargo-semver-checks-action@v1
+
+      - name: Install cargo-release
+        uses: taiki-e/install-action@v1
+        with:
+          tool: cargo-release
+
+      - uses: cargo-bins/release-pr@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          version: ${{ inputs.version }}
+          pr-release-notes: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,13 @@
 [package]
 authors = ["Mason Ginter <mason@dagint.com>", "Elliott Linder <elliott.darfink@gmail.com>"]
 description = "A cross-platform detour library written in Rust"
-# TODO: change doc site once auto-generating docs
-# documentation = "https://docs.rs/detour"
-homepage = "https://github.com/Hpmason/detour-rs"
+documentation = "https://docs.rs/retour"
+homepage = "https://github.com/Hpmason/retour-rs"
 keywords = ["detour", "hook", "function", "api", "redirect"]
 license = "BSD-2-Clause"
-name = "detour" # TODO: come up with another name before publishing
+name = "retour"
 readme = "README.md"
-repository = "https://github.com/Hpmason/detour-rs"
+repository = "https://github.com/Hpmason/retour-rs"
 version = "0.1.0"
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 <div align="center">
 
-# `detour` Fork
+# `retour` (a `detour` Fork)
 
 [![Language (Rust)][rust-shield]][rust]
 
 </div>
 
-(Fork of original [detour-rs](https://github.com/darfink/detour-rs) that works on nightly after nightly-2022-11-07, 
-which added additional trait bounds to Fn-family traits)
+(Fork of original [detour-rs](https://github.com/darfink/detour-rs) 
+that works on nightly after nightly-2022-11-07)
 
 
 This is a cross-platform detour library developed in Rust. Beyond the basic
@@ -46,7 +46,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-detour = {git = "https://github.com/Hpmason/detour-rs.git"}
+retour = {git = "https://github.com/Hpmason/retour-rs.git"}
 ```
 
 ## Example
@@ -55,7 +55,7 @@ detour = {git = "https://github.com/Hpmason/detour-rs.git"}
 
 ```rust
 use std::error::Error;
-use detour::static_detour;
+use retour::static_detour;
 
 static_detour! {
   static Test: /* extern "X" */ fn(i32) -> i32;
@@ -103,8 +103,11 @@ $ cargo build --example messageboxw_detour
 
 ## Mentions
 
+This is fork of the original [detour-rs][detour-rs] creator 
+[darfink][detour-rs-author] that put *so much* work into the original crate.
+
 Part of the library's external user interface was inspired by
-[minhook-rs][minhook], created by [Jascha-N][minhook], and it contains
+[minhook-rs][minhook], created by [Jascha-N][minhook-author], and it contains
 derivative code of his work.
 
 ## Appendix
@@ -136,3 +139,5 @@ derivative code of his work.
 [rust]: https://www.rust-lang.org
 [minhook-author]: https://github.com/Jascha-N
 [minhook]: https://github.com/Jascha-N/minhook-rs/
+[detour-rs]: https://github.com/darfink/detour-rs
+[detour-rs-author]: https://github.com/darfink

--- a/examples/messageboxw_detour.rs
+++ b/examples/messageboxw_detour.rs
@@ -2,7 +2,7 @@
 //! A `MessageBoxW` detour example.
 //!
 //! Ensure the crate is compiled as a 'cdylib' library to allow C interop.
-use detour::static_detour;
+use retour::static_detour;
 use std::error::Error;
 use std::{ffi::CString, iter, mem};
 use winapi::ctypes::c_int;

--- a/src/detours/generic.rs
+++ b/src/detours/generic.rs
@@ -17,8 +17,8 @@ use std::marker::PhantomData;
 /// # Example
 ///
 /// ```rust
-/// # use detour::Result;
-/// use detour::GenericDetour;
+/// # use retour::Result;
+/// use retour::GenericDetour;
 ///
 /// fn add5(val: i32) -> i32 {
 ///   val + 5

--- a/src/detours/raw.rs
+++ b/src/detours/raw.rs
@@ -6,8 +6,8 @@ use crate::error::Result;
 /// # Example
 ///
 /// ```rust
-/// # use detour::Result;
-/// use detour::RawDetour;
+/// # use retour::Result;
+/// use retour::RawDetour;
 /// use std::mem;
 ///
 /// fn add5(val: i32) -> i32 {

--- a/src/detours/statik.rs
+++ b/src/detours/statik.rs
@@ -23,7 +23,7 @@ use std::{mem, ptr};
 ///
 /// ```rust
 /// use std::error::Error;
-/// use detour::static_detour;
+/// use retour::static_detour;
 ///
 /// static_detour! {
 ///   static Test: fn(i32) -> i32;
@@ -88,7 +88,7 @@ impl<T: Function> StaticDetour<T> {
   /// It returns `&self` to allow chaining initialization and activation:
   ///
   /// ```rust
-  /// # use detour::{Result, static_detour};
+  /// # use retour::{Result, static_detour};
   /// # static_detour! {
   /// #   static Test: fn(i32) -> i32;
   /// # }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -17,7 +17,7 @@
 /// # Example
 ///
 /// ```rust
-/// # use detour::static_detour;
+/// # use retour::static_detour;
 /// static_detour! {
 ///   // The simplest detour
 ///   static Foo: fn();

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,4 +1,4 @@
-use detour::Result;
+use retour::Result;
 use std::mem;
 
 type FnAdd = extern "C" fn(i32, i32) -> i32;
@@ -10,7 +10,7 @@ extern "C" fn sub_detour(x: i32, y: i32) -> i32 {
 
 mod raw {
   use super::*;
-  use detour::RawDetour;
+  use retour::RawDetour;
 
   #[test]
   fn test() -> Result<()> {
@@ -51,7 +51,7 @@ mod raw {
 
 mod generic {
   use super::*;
-  use detour::GenericDetour;
+  use retour::GenericDetour;
 
   #[test]
   fn test() -> Result<()> {
@@ -82,7 +82,7 @@ mod generic {
 #[cfg(feature = "nightly")]
 mod statik {
   use super::*;
-  use detour::static_detour;
+  use retour::static_detour;
 
   #[inline(never)]
   unsafe extern "C" fn add(x: i32, y: i32) -> i32 {


### PR DESCRIPTION
To publish this crate, and differentiate it from the original crate, I've renamed it retour. I didn't want to follow the confusing [detour2](https://crates.io/crates/detour2), [detour3](https://crates.io/crates/detour3) pattern of forks, but don't want to make seem like a completely new repo, hence the name `retour`.

I've also renamed the repo itself. Sorry for all the people referring to it in their `Cargo.toml`, you should be able to get it from crates.io soon!

This PR just updates naming. Once the the crate is first published to crates.io, I will update the `Cargo.toml` example in the `README.md`