### PR TITLE
fix: GenericDetour doesn't accept unsafe fns

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -201,8 +201,6 @@ macro_rules! impl_hookable {
   };
 
   (@impl_unsafe ($($nm:ident : $ty:ident),*) ($target:ty) ($detour:ty)) => {
-    unsafe impl<Ret: 'static, $($ty: 'static),*> HookableWith<$detour> for $target {}
-
     #[cfg(feature = "nightly")]
     impl<Ret: 'static, $($ty: 'static),*> $crate::StaticDetour<$target> {
       #[doc(hidden)]


### PR DESCRIPTION
The removed line would expand to something like this:
```rs
unsafe impl<Ret: 'static, A: 'static> HookableWith<extern "system" fn(A) -> Ret>
  for unsafe extern "system" fn(A) -> Ret
{
}
```

This lets `GenericDetour` work with unsafe fns on Rust stable (currently 1.69.0). I'm not sure if this change breaks anything.