### PR TITLE
Seperate required nightly feature into optional features (Make crate stable-first!)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,10 +35,12 @@ static-detour = ["nightly"]
 
 [[example]]
 name = "messageboxw_detour"
+required-features = ["static-detour"]
 crate-type = ["cdylib"]
 
 [[example]]
 name = "cat_detour"
+required-features = ["static-detour"]
 crate-type = ["cdylib"]
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,8 @@ ctor = "0.2.2"
 [features]
 default = []
 nightly = []
+thiscall-abi = ["nightly"]
+static-detour = ["nightly"]
 
 [[example]]
 name = "messageboxw_detour"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,3 +51,7 @@ udis = { package = "libudis86-sys", version = "0.2.1" }
 [target."cfg(windows)".dev-dependencies.windows]
 version = "0.48"
 features = ["Win32_Foundation", "Win32_System_LibraryLoader", "Win32_System_SystemServices"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ matches = "0.1.10"
 ctor = "0.2.2"
 
 [features]
-default = ["nightly"]
+default = []
 nightly = []
 
 [[example]]

--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ maintain this feature, not all desired functionality can be supported due to
 lack of cross-platform APIs. Therefore [EIP relocation](#appendix) is not
 supported.
 
-**NOTE**: Nightly is currently required for `static_detour!` and is enabled by
-default.
+**NOTE**: Nightly is currently required for `static_detour!` and is enabled with the `static-detour` feature flag.
 
 ## Platforms
 
@@ -46,7 +45,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-retour = "0.1"
+retour = "0.2"
 ```
 
 ## Example
@@ -98,7 +97,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
 - A Windows API hooking example is available [here](./examples/messageboxw_detour.rs); build it by running:
 ```
-$ cargo build --example messageboxw_detour
+$ cargo build --features="static-detour" --example messageboxw_detour
 ```
 
 ## Mentions

--- a/examples/cat_detour.rs
+++ b/examples/cat_detour.rs
@@ -1,4 +1,4 @@
-#![cfg(all(not(windows), feature = "nightly"))]
+#![cfg(all(not(windows), feature = "static-detour"))]
 
 use retour::static_detour;
 use std::ffi::CString;

--- a/examples/messageboxw_detour.rs
+++ b/examples/messageboxw_detour.rs
@@ -1,4 +1,4 @@
-#![cfg(all(windows, feature = "nightly"))]
+#![cfg(all(windows, feature = "static-detour"))]
 //! A `MessageBoxW` detour example.
 //!
 //! Ensure the crate is compiled as a 'cdylib' library to allow C interop.

--- a/src/detours/mod.rs
+++ b/src/detours/mod.rs
@@ -8,6 +8,7 @@ pub use self::raw::*;
 
 cfg_if! {
     if #[cfg(feature = "static-detour")] {
+        #[cfg_attr(docsrs, doc(cfg(feature = "static-detour")))]
         mod statik;
         pub use self::statik::*;
     }

--- a/src/detours/mod.rs
+++ b/src/detours/mod.rs
@@ -7,9 +7,8 @@ pub use self::generic::*;
 pub use self::raw::*;
 
 cfg_if! {
-    if #[cfg(feature = "nightly")] {
+    if #[cfg(feature = "static-detour")] {
         mod statik;
         pub use self::statik::*;
-    } else {
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![recursion_limit = "1024"]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(
   feature = "static-detour",
   feature(unboxed_closures, tuple_trait)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,9 +50,11 @@
 //!
 //! ## Features
 //!
-//! - **nightly**: Enabled by default. Required for static detours, due to usage
-//!   of *const_fn* & *unboxed_closures*.   The feature also enables a more
-//!   extensive test suite.
+//! - **static-detour**: Required for static detours, due to usage
+//!   of *unboxed_closures* and *tuple_trait*. The feature also enables a more
+//!   extensive test suite. *Requires nightly compiler*
+//! - **thiscall-abi**: Required for hooking functions that use the "thiscall" ABI, which is 
+//!   nightly only. *Requires nightly compiler*
 //!
 //! ## Platforms
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,15 @@
 #![recursion_limit = "1024"]
 #![cfg_attr(
-  feature = "nightly",
-  feature(unboxed_closures, abi_thiscall, tuple_trait)
+  feature = "static-detour",
+  feature(unboxed_closures, tuple_trait)
 )]
 #![cfg_attr(
-  all(feature = "nightly", test),
-  feature(naked_functions, core_intrinsics)
+  all(feature = "static-detour", test),
+  feature(naked_functions)
+)]
+#![cfg_attr(
+  feature = "thiscall-abi",
+  feature(abi_thiscall)
 )]
 
 //! A cross-platform detour library written in Rust.

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -31,6 +31,7 @@
 /// # fn main() { }
 /// ```
 #[cfg(feature = "static-detour")]
+#[cfg_attr(docsrs, doc(cfg(feature = "static-detour")))]
 #[macro_export]
 // Inspired by: https://github.com/Jascha-N/minhook-rs
 macro_rules! static_detour {
@@ -185,6 +186,7 @@ macro_rules! impl_hookable {
     impl_hookable!(@impl_pair ($($nm : $ty),*) (extern "system"   fn($($ty),*) -> Ret));
 
     #[cfg(feature = "thiscall-abi")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "thiscall-abi")))]
     impl_hookable!(@impl_pair ($($nm : $ty),*) (extern "thiscall" fn($($ty),*) -> Ret));
   };
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -30,7 +30,7 @@
 /// }
 /// # fn main() { }
 /// ```
-#[cfg(feature = "nightly")]
+#[cfg(feature = "static-detour")]
 #[macro_export]
 // Inspired by: https://github.com/Jascha-N/minhook-rs
 macro_rules! static_detour {
@@ -184,7 +184,7 @@ macro_rules! impl_hookable {
     impl_hookable!(@impl_pair ($($nm : $ty),*) (extern "C"        fn($($ty),*) -> Ret));
     impl_hookable!(@impl_pair ($($nm : $ty),*) (extern "system"   fn($($ty),*) -> Ret));
 
-    #[cfg(feature = "nightly")]
+    #[cfg(feature = "thiscall-abi")]
     impl_hookable!(@impl_pair ($($nm : $ty),*) (extern "thiscall" fn($($ty),*) -> Ret));
   };
 
@@ -201,7 +201,7 @@ macro_rules! impl_hookable {
   };
 
   (@impl_unsafe ($($nm:ident : $ty:ident),*) ($target:ty) ($detour:ty)) => {
-    #[cfg(feature = "nightly")]
+    #[cfg(feature = "static-detour")]
     impl<Ret: 'static, $($ty: 'static),*> $crate::StaticDetour<$target> {
       #[doc(hidden)]
       pub unsafe fn call(&self, $($nm : $ty),*) -> Ret {
@@ -220,7 +220,7 @@ macro_rules! impl_hookable {
   };
 
   (@impl_safe ($($nm:ident : $ty:ident),*) ($fn_type:ty)) => {
-    #[cfg(feature = "nightly")]
+    #[cfg(feature = "static-detour")]
     impl<Ret: 'static, $($ty: 'static),*> $crate::StaticDetour<$fn_type> {
       #[doc(hidden)]
       pub fn call(&self, $($nm : $ty),*) -> Ret {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -79,7 +79,7 @@ mod generic {
   }
 }
 
-#[cfg(feature = "nightly")]
+#[cfg(feature = "static-detour")]
 mod statik {
   use super::*;
   use retour::static_detour;


### PR DESCRIPTION
The `nightly` feature flag is now split into 2 features:
- `static-detour` for the `StaticDetour` struct and `static_detour!` macro
- `thiscall-abi` for automatic `Function` implementations for "thiscall" ABI functions, which are nightly only

The biggest change is that these will be ***optional*** features, so now the crate will be **stable by default**! Yay! 

(Closes #19, #21 )