### PR TITLE
Fix import static detour

### DIFF
--- a/src/detours/statik.rs
+++ b/src/detours/statik.rs
@@ -198,7 +198,7 @@ impl<T: Function> Drop for StaticDetour<T> {
 
     let previous = self.detour.swap(ptr::null_mut(), Ordering::Relaxed);
     if !previous.is_null() {
-      unsafe { Box::from_raw(previous) };
+      unsafe { let _ = Box::from_raw(previous); };
     }
   }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -37,80 +37,80 @@
 macro_rules! static_detour {
   // 1 — meta attributes
   (@parse_attributes ($($input:tt)*) | #[$attribute:meta] $($rest:tt)*) => {
-    static_detour!(@parse_attributes ($($input)* $attribute) | $($rest)*);
+    $crate::static_detour!(@parse_attributes ($($input)* $attribute) | $($rest)*);
   };
   (@parse_attributes ($($input:tt)*) | $($rest:tt)+) => {
-    static_detour!(@parse_access_modifier (($($input)*)) | $($rest)*);
+    $crate::static_detour!(@parse_access_modifier (($($input)*)) | $($rest)*);
   };
 
   // 2 — pub modifier (path/scope/yes/no)
   (@parse_access_modifier ($($input:tt)*) | pub(in $vis:path) static $($rest:tt)*) => {
-    static_detour!(@parse_name ($($input)* (pub(in $vis))) | $($rest)*);
+    $crate::static_detour!(@parse_name ($($input)* (pub(in $vis))) | $($rest)*);
   };
   (@parse_access_modifier ($($input:tt)*) | pub($vis:tt) static $($rest:tt)*) => {
-    static_detour!(@parse_name ($($input)* (pub($vis))) | $($rest)*);
+    $crate::static_detour!(@parse_name ($($input)* (pub($vis))) | $($rest)*);
   };
   (@parse_access_modifier ($($input:tt)*) | pub static $($rest:tt)*) => {
-    static_detour!(@parse_name ($($input)* (pub)) | $($rest)*);
+    $crate::static_detour!(@parse_name ($($input)* (pub)) | $($rest)*);
   };
   (@parse_access_modifier ($($input:tt)*) | static $($rest:tt)*) => {
-    static_detour!(@parse_name ($($input)* ()) | $($rest)*);
+    $crate::static_detour!(@parse_name ($($input)* ()) | $($rest)*);
   };
 
   // 3 — detour name
   (@parse_name ($($input:tt)*) | $name:ident : $($rest:tt)*) => {
-    static_detour!(@parse_unsafe ($($input)* ($name)) | $($rest)*);
+    $crate::static_detour!(@parse_unsafe ($($input)* ($name)) | $($rest)*);
   };
 
   // 4 — unsafe modifier (yes/no)
   (@parse_unsafe ($($input:tt)*) | unsafe $($rest:tt)*) => {
-    static_detour!(@parse_calling_convention ($($input)*) (unsafe) | $($rest)*);
+    $crate::static_detour!(@parse_calling_convention ($($input)*) (unsafe) | $($rest)*);
   };
   (@parse_unsafe ($($input:tt)*) | $($rest:tt)*) => {
-    static_detour!(@parse_calling_convention ($($input)*) () | $($rest)*);
+    $crate::static_detour!(@parse_calling_convention ($($input)*) () | $($rest)*);
   };
 
   // 5 — calling convention (extern "XXX"/extern/-)
   (@parse_calling_convention
       ($($input:tt)*) ($($modifier:tt)*) | extern $cc:tt fn $($rest:tt)*) => {
-    static_detour!(@parse_prototype ($($input)* ($($modifier)* extern $cc)) | $($rest)*);
+    $crate::static_detour!(@parse_prototype ($($input)* ($($modifier)* extern $cc)) | $($rest)*);
   };
   (@parse_calling_convention
       ($($input:tt)*) ($($modifier:tt)*) | extern fn $($rest:tt)*) => {
-    static_detour!(@parse_prototype ($($input)* ($($modifier)* extern)) | $($rest)*);
+    $crate::static_detour!(@parse_prototype ($($input)* ($($modifier)* extern)) | $($rest)*);
   };
   (@parse_calling_convention ($($input:tt)*) ($($modifier:tt)*) | fn $($rest:tt)*) => {
-    static_detour!(@parse_prototype ($($input)* ($($modifier)*)) | $($rest)*);
+    $crate::static_detour!(@parse_prototype ($($input)* ($($modifier)*)) | $($rest)*);
   };
 
   // 6 — argument and return type (return/void)
   (@parse_prototype
       ($($input:tt)*) | ($($argument_type:ty),*) -> $return_type:ty ; $($rest:tt)*) => {
-    static_detour!(
+    $crate::static_detour!(
       @parse_terminator ($($input)* ($($argument_type)*) ($return_type)) | ; $($rest)*);
   };
   (@parse_prototype ($($input:tt)*) | ($($argument_type:ty),*) $($rest:tt)*) => {
-    static_detour!(@parse_terminator ($($input)* ($($argument_type)*) (())) | $($rest)*);
+    $crate::static_detour!(@parse_terminator ($($input)* ($($argument_type)*) (())) | $($rest)*);
   };
 
   // 7 — semicolon terminator
   (@parse_terminator ($($input:tt)*) | ; $($rest:tt)*) => {
-    static_detour!(@parse_entries ($($input)*) | $($rest)*);
+    $crate::static_detour!(@parse_entries ($($input)*) | $($rest)*);
   };
 
   // 8 - additional detours (multiple/single)
   (@parse_entries ($($input:tt)*) | $($rest:tt)+) => {
-    static_detour!(@aggregate $($input)*);
-    static_detour!($($rest)*);
+    $crate::static_detour!(@aggregate $($input)*);
+    $crate::static_detour!($($rest)*);
   };
   (@parse_entries ($($input:tt)*) | ) => {
-    static_detour!(@aggregate $($input)*);
+    $crate::static_detour!(@aggregate $($input)*);
   };
 
   // 9 - aggregate data for the generate function
   (@aggregate ($($attribute:meta)*) ($($visibility:tt)*) ($name:ident)
               ($($modifier:tt)*) ($($argument_type:ty)*) ($return_type:ty)) => {
-    static_detour!(@argument_names (create_detour)(
+    $crate::static_detour!(@argument_names (create_detour)(
       ($($attribute)*) ($($visibility)*) ($name)
       ($($modifier)*) ($($argument_type)*) ($return_type)
       ($($modifier)* fn ($($argument_type),*) -> $return_type)
@@ -121,7 +121,7 @@ macro_rules! static_detour {
   (@create_detour ($($argument_name:ident)*) ($($attribute:meta)*) ($($visibility:tt)*)
                   ($name:ident) ($($modifier:tt)*) ($($argument_type:ty)*)
                   ($return_type:ty) ($fn_type:ty)) => {
-    static_detour!(@generate
+    $crate::static_detour!(@generate
       #[allow(non_upper_case_globals)]
       $(#[$attribute])*
       $($visibility)* static $name: $crate::StaticDetour<$fn_type> = {
@@ -140,7 +140,7 @@ macro_rules! static_detour {
 
   // Associates each argument type with a dummy name.
   (@argument_names ($label:ident) ($($input:tt)*) ($($token:tt)*)) => {
-    static_detour!(@argument_names ($label) ($($input)*)(
+    $crate::static_detour!(@argument_names ($label) ($($input)*)(
       __arg_0  __arg_1  __arg_2  __arg_3  __arg_4  __arg_5  __arg_6
       __arg_7  __arg_8  __arg_9  __arg_10 __arg_11 __arg_12 __arg_13
     )($($token)*)());
@@ -150,18 +150,18 @@ macro_rules! static_detour {
       ($($input:tt)*)
       ($hd_name:tt $($tl_name:tt)*)
       ($hd:tt $($tl:tt)*) ($($acc:tt)*)) => {
-    static_detour!(
+    $crate::static_detour!(
       @argument_names ($label) ($($input)*) ($($tl_name)*) ($($tl)*) ($($acc)* $hd_name));
   };
   (@argument_names ($label:ident) ($($input:tt)*) ($($name:tt)*) () ($($acc:tt)*)) => {
-    static_detour!(@$label ($($acc)*) $($input)*);
+    $crate::static_detour!(@$label ($($acc)*) $($input)*);
   };
 
   (@generate $item:item) => { $item };
 
   // Bootstrapper
   ($($t:tt)+) => {
-    static_detour!(@parse_attributes () | $($t)+);
+    $crate::static_detour!(@parse_attributes () | $($t)+);
   };
 }
 


### PR DESCRIPTION
`static_detour` macro assumed the macro was imported in the current scope with its recursive calls. It now properly uses the crate path in the recursive macro call (fixes #29)