### PR TITLE
fix: remove feature requirement for thiscall

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,7 @@ nightly compiler will always target the newest version.
 
 Feature versions:
 - `static-detour`: nightly
-- `thiscall-abi`: nightly (will be [stabilized in 1.73.0](https://releases.rs/docs/1.73.0/))
- 
+- `thiscall-abi`: 1.73.0 or newer
 
 ## Example
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,8 +55,7 @@
 //! - **static-detour**: Required for static detours, due to usage
 //!   of *unboxed_closures* and *tuple_trait*. The feature also enables a more
 //!   extensive test suite. *Requires nightly compiler*
-//! - **thiscall-abi**: Required for hooking functions that use the "thiscall" ABI, which is 
-//!   nightly only. *Requires nightly compiler*
+//! - **thiscall-abi**: Required for hooking functions that use the "thiscall" ABI. *Requires 1.73.0 or greater*
 //!
 //! ## Platforms
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,10 +8,6 @@
   all(feature = "static-detour", test),
   feature(naked_functions)
 )]
-#![cfg_attr(
-  feature = "thiscall-abi",
-  feature(abi_thiscall)
-)]
 
 //! A cross-platform detour library written in Rust.
 //!

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -184,6 +184,9 @@ macro_rules! impl_hookable {
     impl_hookable!(@impl_pair ($($nm : $ty),*) (extern "win64"    fn($($ty),*) -> Ret));
     impl_hookable!(@impl_pair ($($nm : $ty),*) (extern "C"        fn($($ty),*) -> Ret));
     impl_hookable!(@impl_pair ($($nm : $ty),*) (extern "system"   fn($($ty),*) -> Ret));
+
+    #[cfg(feature = "thiscall-abi")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "thiscall-abi")))]
     impl_hookable!(@impl_pair ($($nm : $ty),*) (extern "thiscall" fn($($ty),*) -> Ret));
   };
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -184,9 +184,6 @@ macro_rules! impl_hookable {
     impl_hookable!(@impl_pair ($($nm : $ty),*) (extern "win64"    fn($($ty),*) -> Ret));
     impl_hookable!(@impl_pair ($($nm : $ty),*) (extern "C"        fn($($ty),*) -> Ret));
     impl_hookable!(@impl_pair ($($nm : $ty),*) (extern "system"   fn($($ty),*) -> Ret));
-
-    #[cfg(feature = "thiscall-abi")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "thiscall-abi")))]
     impl_hookable!(@impl_pair ($($nm : $ty),*) (extern "thiscall" fn($($ty),*) -> Ret));
   };
 


### PR DESCRIPTION
abi_thiscall is now considered stable by rust
https://github.com/rust-lang/rust/commit/06daa9e263db87b3c5d4d80110938130db846183