### PR TITLE
Document Supported Versions

### DIFF
--- a/.github/workflows/nightly-check.yml
+++ b/.github/workflows/nightly-check.yml
@@ -1,0 +1,32 @@
+on:
+  schedule:
+    # Run once a week
+    - cron: "0 0 * * 0"
+  workflow_dispatch:
+
+jobs:
+  nightly-test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: nightly
+        targets: ${{ matrix.target.triple }}
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: stable
+        targets: ${{ matrix.target.triple }}
+    # Install linux deps
+    - if: matrix.os == 'ubuntu-latest'
+      run: sudo apt-get update && sudo apt-get install gcc-multilib
+    
+    - name: Cargo Check - All Features
+      run: ${{ matrix.target.rustflags }} cargo +nightly check --target ${{ matrix.target.triple }} --all-features
+    
+    - name: Cargo Tests - Nightly
+      run: ${{ matrix.target.rustflags }} cargo +nightly test --target ${{ matrix.target.triple }} --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 repository = "https://github.com/Hpmason/retour-rs"
 version = "0.3.1"
 edition = "2018"
+rust-version = "1.60.0"
 
 # [badges]
 # azure-devops = { project = "darfink/detour-rs", pipeline = "darfink.detour-rs" }

--- a/README.md
+++ b/README.md
@@ -63,6 +63,17 @@ Add this to your `Cargo.toml`:
 retour = { version = "0.3", features = ["static-detour"] }
 ```
 
+## Supported Versions
+This crate, with default features, will support the MSRV in `Cargo.toml` 
+(currently 1.60.0). Certain features may require newer versions of the compiler, 
+which will be documented here and in the docs. Any features that require the 
+nightly compiler will always target the newest version.
+
+Feature versions:
+- `static-detour`: nightly
+- `thiscall-abi`: nightly (will be [stabilized in 1.73.0](https://releases.rs/docs/1.73.0/))
+ 
+
 ## Example
 
 - A static detour (one of *three* different detours):

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,12 @@
 //!   others types abstract upon. It has no type-safety and interacts with raw
 //!   pointers. It should be avoided unless any types are references, or not
 //!   known until runtime.
+//! 
+//! ## Supported Versions
+//! This crate, with default features, will support the MSRV in `Cargo.toml` 
+//! (currently 1.60.0). Certain features may require newer versions of the 
+//! compiler, which will be documented here and in the docs. Any features 
+//! that require the nightly compiler will always target the newest version.
 //!
 //! ## Features
 //!


### PR DESCRIPTION
Resolves #35 

Adds docs on what versions this crate supports and how to handle feature stabilization.