### PR TITLE
Expose trampoline() on Generic and Static Detour

### DIFF
--- a/src/detours/generic.rs
+++ b/src/detours/generic.rs
@@ -81,7 +81,7 @@ impl<T: Function> GenericDetour<T> {
   }
 
   /// Returns a reference to the generated trampoline.
-  pub(crate) fn trampoline(&self) -> &() {
+  pub fn trampoline(&self) -> &() {
     self.detour.trampoline()
   }
 }

--- a/src/detours/statik.rs
+++ b/src/detours/statik.rs
@@ -168,7 +168,7 @@ impl<T: Function> StaticDetour<T> {
   }
 
   /// Returns a reference to the generated trampoline.
-  pub(crate) fn trampoline(&self) -> Result<&()> {
+  pub fn trampoline(&self) -> Result<&()> {
     Ok(
       unsafe { self.detour.load(Ordering::SeqCst).as_ref() }
         .ok_or(Error::NotInitialized)?


### PR DESCRIPTION
I needed to pass the address of the trampoline function to a C function so I made the `trampoline()` function public. My previous workaround was using `RawDetour` but that was annoying and seeing that `RawDetour` already exposes the trampoline function, I think it would be appropriate for `StaticDetour` and `GenericDetour` to have it too