### PR TITLE
Support Detouring Functions With >14 Args

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ default = []
 nightly = []
 thiscall-abi = ["nightly"]
 static-detour = ["nightly"]
+extra-impls = []
 
 [[example]]
 name = "messageboxw_detour"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,8 @@ default = []
 nightly = []
 thiscall-abi = ["nightly"]
 static-detour = ["nightly"]
-extra-impls = []
+28-args = []
+42-args = ["28-args"]
 
 [[example]]
 name = "messageboxw_detour"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,8 @@
 //!   of *unboxed_closures* and *tuple_trait*. The feature also enables a more
 //!   extensive test suite. *Requires nightly compiler*
 //! - **thiscall-abi**: Required for hooking functions that use the "thiscall" ABI. *Requires 1.73.0 or greater*
-//! - **extra-impls**: Allows for detouring functions more than 14 arguments (up to 26 arguments)
+//! - **28-args**: Allows for detouring functions up to 28 arguments (default is 14)
+//! - **42-args**: Allows for detouring functions up to 42 arguments
 //!
 //! ## Platforms
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,7 @@
 //!   of *unboxed_closures* and *tuple_trait*. The feature also enables a more
 //!   extensive test suite. *Requires nightly compiler*
 //! - **thiscall-abi**: Required for hooking functions that use the "thiscall" ABI. *Requires 1.73.0 or greater*
+//! - **extra-impls**: Allows for detouring functions more than 14 arguments (up to 26 arguments)
 //!
 //! ## Platforms
 //!

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -141,8 +141,10 @@ macro_rules! static_detour {
   // Associates each argument type with a dummy name.
   (@argument_names ($label:ident) ($($input:tt)*) ($($token:tt)*)) => {
     $crate::static_detour!(@argument_names ($label) ($($input)*)(
-      __arg_0  __arg_1  __arg_2  __arg_3  __arg_4  __arg_5  __arg_6
-      __arg_7  __arg_8  __arg_9  __arg_10 __arg_11 __arg_12 __arg_13
+      __arg_0   __arg_1   __arg_2  __arg_3  __arg_4  __arg_5  __arg_6
+      __arg_7   __arg_8   __arg_9  __arg_10 __arg_11 __arg_12 __arg_13
+      __arg_14  __arg_15  __arg_16 __arg_17 __arg_18 __arg_19 __arg_20
+      __arg_21  __arg_22  __arg_23 __arg_24 __arg_25
     )($($token)*)());
   };
   (@argument_names

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -24,16 +24,26 @@ pub unsafe trait HookableWith<D: Function>: Function {}
 
 unsafe impl<T: Function> HookableWith<T> for T {}
 
-#[cfg(not(feature = "extra-impls"))]
+#[cfg(not(feature = "28-args"))]
 impl_hookable! {
   __arg_0:  A, __arg_1:  B, __arg_2:  C, __arg_3:  D, __arg_4:  E, __arg_5:  F, __arg_6:  G,
   __arg_7:  H, __arg_8:  I, __arg_9:  J, __arg_10: K, __arg_11: L, __arg_12: M, __arg_13: N
 }
 
-#[cfg(feature = "extra-impls")]
+#[cfg(all(feature = "28-args", not(feature = "42-args")))]
 impl_hookable! {
   __arg_0:  A, __arg_1:  B, __arg_2:  C, __arg_3:  D, __arg_4:  E, __arg_5:  F, __arg_6:  G,
   __arg_7:  H, __arg_8:  I, __arg_9:  J, __arg_10: K, __arg_11: L, __arg_12: M, __arg_13: N,
   __arg_14: O, __arg_15: P, __arg_16: Q, __arg_17: R, __arg_18: S, __arg_19: T, __arg_20: U,
-  __arg_21: V, __arg_22: W, __arg_23: X, __arg_24: Y, __arg_25: Z
+  __arg_21: V, __arg_22: W, __arg_23: X, __arg_24: Y, __arg_25: Z, __arg_26: AA, __arg27: AB
+}
+
+#[cfg(feature = "42-args")]
+impl_hookable! {
+  __arg_0:   A, __arg_1:   B, __arg_2:   C, __arg_3:   D, __arg_4:   E, __arg_5:   F, __arg_6:   G,
+  __arg_7:   H, __arg_8:   I, __arg_9:   J, __arg_10:  K, __arg_11:  L, __arg_12:  M, __arg_13:  N,
+  __arg_14:  O, __arg_15:  P, __arg_16:  Q, __arg_17:  R, __arg_18:  S, __arg_19:  T, __arg_20:  U,
+  __arg_21:  V, __arg_22:  W, __arg_23:  X, __arg_24:  Y, __arg_25:  Z, __arg_26: AA, __arg_27: AB,
+  __arg_28: AC, __arg_29: AD, __arg_30: AE, __arg_31: AF, __arg_32: AG, __arg_33: AH, __arg_34: AI,
+  __arg_35: AJ, __arg_36: AK, __arg_37: AL, __arg_38: AM, __arg_39: AN, __arg_40: AO, __arg_41: AP
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -24,7 +24,16 @@ pub unsafe trait HookableWith<D: Function>: Function {}
 
 unsafe impl<T: Function> HookableWith<T> for T {}
 
+#[cfg(not(feature = "extra-impls"))]
 impl_hookable! {
   __arg_0:  A, __arg_1:  B, __arg_2:  C, __arg_3:  D, __arg_4:  E, __arg_5:  F, __arg_6:  G,
   __arg_7:  H, __arg_8:  I, __arg_9:  J, __arg_10: K, __arg_11: L, __arg_12: M, __arg_13: N
+}
+
+#[cfg(feature = "extra-impls")]
+impl_hookable! {
+  __arg_0:  A, __arg_1:  B, __arg_2:  C, __arg_3:  D, __arg_4:  E, __arg_5:  F, __arg_6:  G,
+  __arg_7:  H, __arg_8:  I, __arg_9:  J, __arg_10: K, __arg_11: L, __arg_12: M, __arg_13: N,
+  __arg_14: O, __arg_15: P, __arg_16: Q, __arg_17: R, __arg_18: S, __arg_19: T, __arg_20: U,
+  __arg_21: V, __arg_22: W, __arg_23: X, __arg_24: Y, __arg_25: Z
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -8,6 +8,7 @@ extern "C" fn sub_detour(x: i32, y: i32) -> i32 {
   unsafe { std::ptr::read_volatile(&x as *const i32) - y }
 }
 
+
 mod raw {
   use super::*;
   use retour::RawDetour;
@@ -115,5 +116,14 @@ mod statik {
       assert_eq!(add(10, 5), 15);
     }
     Ok(())
+  }
+}
+
+#[cfg(all(feature = "extra-impls", feature = "static-detour"))]
+mod extra_impls {
+  use retour::static_detour;
+
+  static_detour! {
+    pub static big_fn: fn(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32);
   }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -119,11 +119,39 @@ mod statik {
   }
 }
 
-#[cfg(all(feature = "extra-impls", feature = "static-detour"))]
-mod extra_impls {
-  use retour::static_detour;
+#[cfg(feature = "28-args")]
+mod args_28 {
+  use super::*;
+  use retour::GenericDetour;
 
-  static_detour! {
-    pub static big_fn: fn(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32);
+
+  type I = i32;
+  type BigFn = fn(I, I, I, I, I, I, I, I, I, I, I, I, I, I, I, I, I, I, I, I);
+
+  fn a(_: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I) {}
+  fn b(_: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I) {}
+  #[test]
+  fn sanity_check() -> Result<()> {
+    let hook = unsafe { GenericDetour::<BigFn>::new(a, b) };
+    Ok(())
+  }
+}
+#[cfg(feature = "42-args")]
+mod args_42 {
+  use super::*;
+  use retour::GenericDetour;
+
+
+  type I = i32;
+  type BiggerFn = fn(I, I, I, I, I, I, I, I, I, I, I, I, I, I, I, I, I, I, I, I, I, I, I, I, I, I, I, I, I, I, I, I, I, I, I, I, I, I, I, I);
+
+  fn a(_: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I,
+    _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I) {}
+  fn b(_: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I,
+    _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I, _: I) {}
+  #[test]
+  fn sanity_check() -> Result<()> {
+    let hook = unsafe { GenericDetour::<BiggerFn>::new(a, b)? };
+    Ok(())
   }
 }


### PR DESCRIPTION
Adds a feature that increases the number of args in detourable functions (from 14 to 26). Putting behind a feature since it may increase compilation times. I want to do more investigation to see if it actually has a negligible effect on comp times, since it may make more sense to not put behind feature.

If put behind feature, I'd want to add docs.rs macros so that the docs more clearly state the that more arguments are behind the feature `extra-impls`. e.g.:
```rust
#[cfg(feature = "extra-impls")]
#[cfg_attr(docsrs, doc(cfg(feature = "extra-impls")))]
```

Resolves #52 