### PR TITLE
Fix Detour not Disabling on Drop in Release Mode

### DIFF
--- a/src/arch/detour.rs
+++ b/src/arch/detour.rs
@@ -111,7 +111,8 @@ impl Detour {
 impl Drop for Detour {
   /// Disables the detour, if enabled.
   fn drop(&mut self) {
-    debug_assert!(unsafe { self.disable().is_ok() });
+    let did_succeed = unsafe { self.disable() }.is_ok();
+    debug_assert!(did_succeed);
   }
 }
 


### PR DESCRIPTION
Fixes #43 

For anyone wanting to keep original release mode, you can wrap the detour in [`ManuallyDrop`](https://doc.rust-lang.org/stable/std/mem/struct.ManuallyDrop.html) or leak the resource with [`Box::leak`](https://doc.rust-lang.org/stable/std/boxed/struct.Box.html#method.leak) or [`mem::forget`](https://doc.rust-lang.org/stable/std/mem/fn.forget.html).