### PR TITLE
Add thiscall support

### DIFF
--- a/src/arch/x86/trampoline/mod.rs
+++ b/src/arch/x86/trampoline/mod.rs
@@ -3,7 +3,6 @@ use crate::arch::x86::thunk;
 use crate::error::{Error, Result};
 use crate::pic;
 use iced_x86::{Decoder, DecoderOptions, Instruction};
-use std::ptr::slice_from_raw_parts;
 use std::{mem, slice};
 
 mod disasm;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -181,6 +181,7 @@ macro_rules! impl_hookable {
     impl_hookable!(@impl_pair ($($nm : $ty),*) (extern "cdecl"    fn($($ty),*) -> Ret));
     impl_hookable!(@impl_pair ($($nm : $ty),*) (extern "stdcall"  fn($($ty),*) -> Ret));
     impl_hookable!(@impl_pair ($($nm : $ty),*) (extern "fastcall" fn($($ty),*) -> Ret));
+    impl_hookable!(@impl_pair ($($nm : $ty),*) (extern "thiscall" fn($($ty),*) -> Ret));
     impl_hookable!(@impl_pair ($($nm : $ty),*) (extern "win64"    fn($($ty),*) -> Ret));
     impl_hookable!(@impl_pair ($($nm : $ty),*) (extern "C"        fn($($ty),*) -> Ret));
     impl_hookable!(@impl_pair ($($nm : $ty),*) (extern "system"   fn($($ty),*) -> Ret));


### PR DESCRIPTION
Pretty straightforward PR - adds `thiscall` support to the list of hookable functions, which is used for member functions on x86 Windows. I also removed an import that `rustc` warned wasn't being used; I checked and it doesn't seem to be used anywhere, even under compile guards.