### PR TITLE
Add `-unwind` versions of the hooks, and make them helper functions `-unwind` too.

### DIFF
--- a/src/arch/x86/mod.rs
+++ b/src/arch/x86/mod.rs
@@ -18,7 +18,7 @@ mod tests {
   use std::mem;
 
   /// Default test case function definition.
-  type CRet = unsafe extern "C" fn() -> i32;
+  type CRet = unsafe extern "C-unwind" fn() -> i32;
 
   /// Detours a C function returning an integer, and asserts its return value.
   #[inline(never)]
@@ -40,7 +40,7 @@ mod tests {
   #[test]
   fn detour_relative_branch() -> Result<()> {
     #[naked]
-    unsafe extern "C" fn branch_ret5() -> i32 {
+    unsafe extern "C-unwind" fn branch_ret5() -> i32 {
       naked_asm!(
         "
             xor eax, eax
@@ -60,7 +60,7 @@ mod tests {
   #[test]
   fn detour_hotpatch() -> Result<()> {
     #[naked]
-    unsafe extern "C" fn hotpatch_ret0() -> i32 {
+    unsafe extern "C-unwind" fn hotpatch_ret0() -> i32 {
       naked_asm!(
         "
             nop
@@ -80,7 +80,7 @@ mod tests {
   #[test]
   fn detour_padding_after() -> Result<()> {
     #[naked]
-    unsafe extern "C" fn padding_after_ret0() -> i32 {
+    unsafe extern "C-unwind" fn padding_after_ret0() -> i32 {
       naked_asm!(
         "
             mov edi, edi
@@ -97,7 +97,7 @@ mod tests {
   #[test]
   fn detour_external_loop() {
     #[naked]
-    unsafe extern "C" fn external_loop() -> i32 {
+    unsafe extern "C-unwind" fn external_loop() -> i32 {
       naked_asm!(
         "
             loop 2f
@@ -117,7 +117,7 @@ mod tests {
   #[cfg(target_arch = "x86_64")]
   fn detour_rip_relative_pos() -> Result<()> {
     #[naked]
-    unsafe extern "C" fn rip_relative_ret195() -> i32 {
+    unsafe extern "C-unwind" fn rip_relative_ret195() -> i32 {
       naked_asm!(
         "
             xor eax, eax
@@ -136,7 +136,7 @@ mod tests {
   #[cfg(target_arch = "x86_64")]
   fn detour_rip_relative_neg() -> Result<()> {
     #[naked]
-    unsafe extern "C" fn rip_relative_prolog_ret49() -> i32 {
+    unsafe extern "C-unwind" fn rip_relative_prolog_ret49() -> i32 {
       naked_asm!(
         "
             xor eax, eax
@@ -149,7 +149,7 @@ mod tests {
   }
 
   /// Default detour target.
-  unsafe extern "C" fn ret10() -> i32 {
+  unsafe extern "C-unwind" fn ret10() -> i32 {
     10
   }
 }

--- a/src/arch/x86/trampoline/mod.rs
+++ b/src/arch/x86/trampoline/mod.rs
@@ -3,7 +3,6 @@ use crate::arch::x86::thunk;
 use crate::error::{Error, Result};
 use crate::pic;
 use iced_x86::{Decoder, DecoderOptions, Instruction, OpKind};
-use std::ptr::slice_from_raw_parts;
 use std::{mem, slice};
 
 mod disasm;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -181,15 +181,22 @@ macro_rules! impl_hookable {
   (@impl_all ($($nm:ident : $ty:ident),*)) => {
     impl_hookable!(@impl_pair ($($nm : $ty),*) (                  fn($($ty),*) -> Ret));
     impl_hookable!(@impl_pair ($($nm : $ty),*) (extern "cdecl"    fn($($ty),*) -> Ret));
+    impl_hookable!(@impl_pair ($($nm : $ty),*) (extern "cdecl-unwind"    fn($($ty),*) -> Ret));
     impl_hookable!(@impl_pair ($($nm : $ty),*) (extern "stdcall"  fn($($ty),*) -> Ret));
+    impl_hookable!(@impl_pair ($($nm : $ty),*) (extern "stdcall-unwind"  fn($($ty),*) -> Ret));
     impl_hookable!(@impl_pair ($($nm : $ty),*) (extern "fastcall" fn($($ty),*) -> Ret));
+    impl_hookable!(@impl_pair ($($nm : $ty),*) (extern "fastcall-unwind" fn($($ty),*) -> Ret));
     impl_hookable!(@impl_pair ($($nm : $ty),*) (extern "win64"    fn($($ty),*) -> Ret));
     impl_hookable!(@impl_pair ($($nm : $ty),*) (extern "C"        fn($($ty),*) -> Ret));
+    impl_hookable!(@impl_pair ($($nm : $ty),*) (extern "C-unwind"        fn($($ty),*) -> Ret));
     impl_hookable!(@impl_pair ($($nm : $ty),*) (extern "system"   fn($($ty),*) -> Ret));
 
     #[cfg(feature = "thiscall-abi")]
     #[cfg_attr(docsrs, doc(cfg(feature = "thiscall-abi")))]
     impl_hookable!(@impl_pair ($($nm : $ty),*) (extern "thiscall" fn($($ty),*) -> Ret));
+    #[cfg(feature = "thiscall-abi")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "thiscall-abi")))]
+    impl_hookable!(@impl_pair ($($nm : $ty),*) (extern "thiscall-unwind" fn($($ty),*) -> Ret));
   };
 
   (@impl_pair ($($nm:ident : $ty:ident),*) ($($fn_t:tt)*)) => {


### PR DESCRIPTION
And remove unused `use` in `src/arch/x86/trampoline/mod.rs`,