### PR TITLE
Update to mmap-fixed-fixed 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ cfg-if = "1.0.0"
 generic-array = "0.14.7"
 once_cell = "1.18.0"
 libc = "0.2.145"
-mmap = { package = "mmap-fixed-fixed", version = "0.1.3" }
+mmap = { package = "mmap-fixed-fixed", version = "0.2.0" }
 region = "3.0.0"
 slice-pool = {package = "slice-pool2", version = "0.4.3" }
 


### PR DESCRIPTION
This has some niceities, most notably for users of retour-rs on Windows is moving from winapi to the windows crate.