### PR TITLE
fix building with -Zrandomize-layout

### DIFF
--- a/src/arch/x86/thunk/x64.rs
+++ b/src/arch/x86/thunk/x64.rs
@@ -1,7 +1,7 @@
 use crate::pic::Thunkable;
 use std::mem;
 
-#[repr(packed)]
+#[repr(C, packed)]
 struct CallAbs {
   // call [rip+8]
   opcode0: u8,
@@ -28,7 +28,7 @@ pub fn call_abs(destination: usize) -> Box<dyn Thunkable> {
   Box::new(slice.to_vec())
 }
 
-#[repr(packed)]
+#[repr(C, packed)]
 struct JumpAbs {
   // jmp +6
   opcode0: u8,
@@ -50,7 +50,7 @@ pub fn jmp_abs(destination: usize) -> Box<dyn Thunkable> {
   Box::new(slice.to_vec())
 }
 
-#[repr(packed)]
+#[repr(C, packed)]
 struct JccAbs {
   // jxx + 16
   opcode: u8,

--- a/src/arch/x86/thunk/x86.rs
+++ b/src/arch/x86/thunk/x86.rs
@@ -2,7 +2,7 @@ use crate::pic::{FixedThunk, Thunkable};
 use generic_array::{typenum, GenericArray};
 use std::mem;
 
-#[repr(packed)]
+#[repr(C, packed)]
 pub struct JumpRel {
   opcode: u8,
   operand: u32,
@@ -39,7 +39,7 @@ pub fn jmp_rel32(destination: usize) -> Box<dyn Thunkable> {
   relative32(destination, true)
 }
 
-#[repr(packed)]
+#[repr(C, packed)]
 struct JccRel {
   opcode0: u8,
   opcode1: u8,
@@ -60,7 +60,7 @@ pub fn jcc_rel32(destination: usize, condition: u8) -> Box<dyn Thunkable> {
   }))
 }
 
-#[repr(packed)]
+#[repr(C, packed)]
 pub struct JumpShort {
   opcode: u8,
   operand: i8,


### PR DESCRIPTION
Rust's ABI is not stable at the binary level yet, when the compile flag `-Zrandomize-layout` is used, Rust assumes that it is allowed to randomize the layout of structures such as `CallAbs`, which are supposed to be in a specific layout.

This manifests as an exception at runtime, since the constructed code buffer will be in a random layout. Making it represented as both `C` and `packed` fixes this.

Source: https://doc.rust-lang.org/nomicon/other-reprs.html#reprpacked-reprpackedn

> This repr is a modifier on repr(C) and repr(Rust). For FFI compatibility you most likely always want to be explicit: repr(C, packed).